### PR TITLE
Update for yaml

### DIFF
--- a/fioctl/config.py
+++ b/fioctl/config.py
@@ -7,7 +7,7 @@ class Config():
     @cached_property
     def config(self):
         if self.exists:
-            return yaml.load(open(self.filename))
+            return yaml.load(open(self.filename), Loader=yaml.FullLoader)
         return {}
 
     @property


### PR DESCRIPTION
You get a warning now if you don't use the  `Loader=yaml.FullLoader` code. Adding this to remove warning.