### PR TITLE
update to fix yaml load problem with pyyaml 6.0

### DIFF
--- a/fioctl/config.py
+++ b/fioctl/config.py
@@ -9,7 +9,7 @@ class Config:
     @cached_property
     def config(self):
         if self.exists:
-            return yaml.load(open(self.filename), Loader=yaml.SafeLoader)
+            return yaml.safe_load(open(self.filename), Loader=yaml.SafeLoader)
         return {}
 
     @property


### PR DESCRIPTION
Fresh installs are running into this problem with newer pyyaml version.
This fix will work with newer and older versions of pyyaml.